### PR TITLE
add versions 1.20.5+ to ServerVersion

### DIFF
--- a/src/main/java/tsp/nexuslib/server/ServerVersion.java
+++ b/src/main/java/tsp/nexuslib/server/ServerVersion.java
@@ -30,7 +30,8 @@ public enum ServerVersion {
     v_1_17(755), v_1_17_1(756),
     v_1_18(757), v_1_18_1(757), v_1_18_2(758),
     v_1_19(759), v_1_19_1(760), v_1_19_2(760),
-    v_1_20(763), v_1_20_1(763), v_1_20_2(764), v_1_20_3(765), v_1_20_4(765);
+    v_1_20(763), v_1_20_1(763), v_1_20_2(764), v_1_20_3(765), v_1_20_4(765), v_1_20_5(766), v_1_20_6(766),
+    v_1_21(767);
 
     private static final String NMS_VERSION_SUFFIX = Bukkit.getServer().getClass().getPackage().getName().replace(".", ",").split(",")[3];
     private static final ServerVersion[] VALUES = values();


### PR DESCRIPTION
Hi, my brother and I use HeadDB for our Minecraft server (we are very grateful to you all for maintaining it). My read on [this issue](https://github.com/TheSilentPro/HeadDB/issues/75#issuecomment-2167285560) is that we need to add the newer versions to this enum. Let me know if that is not correct.